### PR TITLE
Include src files in package for source maps

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,7 +9,8 @@
   "typings": "./dist/index.d.ts",
   "license": "MIT",
   "files": [
-    "dist/*"
+    "dist",
+    "src"
   ],
   "repository": {
     "type": "git",


### PR DESCRIPTION
Was getting build warning because a `.map` file was referencing a file that wasn't on my machine. This PR includes the src files so that the source maps work

![Screen Shot 2020-01-22 at 5 29 50 PM](https://user-images.githubusercontent.com/1192452/72949319-d0490580-3d3c-11ea-8495-dd6e70334d05.png)
