### PR TITLE
Fix escape sequences

### DIFF
--- a/HISTORY.md
+++ b/HISTORY.md
@@ -4,6 +4,8 @@
 
 TBA
 
+- Correctly handle escape sequences when used as a tag
+
 ## v2.0.0
 
 Fixes #4

--- a/src/__tests__/index.spec.ts
+++ b/src/__tests__/index.spec.ts
@@ -174,6 +174,17 @@ Line #${1}
       })(),
     ).toEqual('1. line #1\n2. line #2\n3. line');
   });
+
+  it("should process escape sequences", () => {
+    expect(
+      (() => {
+        return dedent`
+          \${not interpolated}
+          \`
+        `;
+      })(),
+    ).toEqual('${not interpolated}\n`');
+  });
 });
 
 describe('dedent() function', () => {
@@ -348,6 +359,15 @@ Line #${1}
       })(),
     ).toEqual('1. line #1\n2. line #2\n3. line');
   });
+
+  it("should process escape sequences", () => {
+    expect(
+      dedent(`
+          \${not interpolated}
+          \`
+        `),
+    ).toEqual('${not interpolated}\n`');
+  });
 });
 
 describe('dedent() function with custom tag', () => {
@@ -521,5 +541,14 @@ Line #${1}
 				`);
       })(),
     ).toEqual('2. line #2\n4. line #4\n6. line');
+  });
+
+  it("should process escape sequences", () => {
+    expect(
+      dedent(tag`
+          \${not interpolated}
+          \`
+        `),
+    ).toEqual('${not interpolated}\n`');
   });
 });

--- a/src/index.ts
+++ b/src/index.ts
@@ -2,7 +2,7 @@ export function dedent(
   templ: TemplateStringsArray | string,
   ...values: unknown[]
 ): string {
-  let strings = Array.from(typeof templ === 'string' ? [templ] : templ.raw);
+  let strings = Array.from(typeof templ === 'string' ? [templ] : templ);
 
   // 1. Remove trailing whitespace.
   strings[strings.length - 1] = strings[strings.length - 1].replace(


### PR DESCRIPTION
This PR fixes a bug where escape sequences aren't processed by dedent when it's used as a tag. 

For example using the following code:

```javascript
console.log(dedent`\${abc}`);
console.log(dedent(`\${abc}`));
```

The expected result is:
```javascript
${abc}
${abc}
```

But the actual behavior is:
```javascript
\${abc}
${abc}
```

I'm not sure if removing `.raw` could have other side effects, but the current tests are passing and from the docs it looks like it shouldn't have any other consequences.