### PR TITLE
Add "exports" to package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,7 +6,12 @@
   "main": "./dist/index.js",
   "module": "./esm/index.js",
   "jsnext:main": "./dist/index.js",
-  "typings": "./dist/index.d.ts",
+  "types": "./dist/index.d.ts",
+  "exports": {
+    "types": "./dist/index.d.ts",
+    "require": "./dist/index.js",
+    "import": "./esm/index.js"
+  },
   "license": "MIT",
   "files": [
     "dist",


### PR DESCRIPTION
Should fix the issue where `import dedent from 'ts-dedent'` doesn't work with Node.js builtin ESM which doesn't support `__esModule`.