### PR TITLE
ci(release): open PR to master instead of pushing directly

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,11 +1,15 @@
 name: Release
 
-# ONE-TIME PREREQUISITES (see the "Releasing" section in README.md):
+# ONE-TIME PREREQUISITES:
 #   1. Configure an npm trusted publisher for `ts-dedent` on npmjs.com
 #      (provider: GitHub Actions, repo: tamino-martinius/node-ts-dedent, workflow: release.yml).
 #      Publishing is tokenless via OIDC `--provenance`; without this, the publish step fails.
-#   2. Branch protection on `master` must allow github-actions[bot] to push the release
-#      commit + tag.
+#   2. Settings -> Actions -> General -> Workflow permissions: enable
+#      "Allow GitHub Actions to create and approve pull requests" so the publish job
+#      can open the version-bump PR to master.
+# This workflow NEVER pushes to master directly. It publishes to npm, tags the release,
+# pushes a `release/v<version>` branch, and opens a PR to master that you merge manually
+# (use a merge commit so the v<version> tag stays in master history).
 # Before dispatching: put the real changelog under "## vNext" in HISTORY.md (replace "TBD").
 
 on:
@@ -19,6 +23,7 @@ on:
 permissions:
   contents: write
   id-token: write
+  pull-requests: write
 
 concurrency:
   group: release
@@ -177,8 +182,10 @@ jobs:
       - name: Upgrade npm (OIDC trusted publishing)
         run: npm install -g npm@latest
       # Commit + tag are created LOCALLY here and pushed only AFTER npm publish
-      # succeeds, so a publish failure (e.g. trusted publisher not yet configured)
-      # leaves master untouched and the release is cleanly retryable.
+      # succeeds, to a dedicated `release/v<version>` branch — never to master. A
+      # publish failure therefore leaves master AND origin untouched, and the release
+      # is cleanly retryable. The version bump reaches master only when you merge the
+      # PR opened at the end of this job.
       - name: Commit and tag (local)
         env:
           VERSION: ${{ inputs.version }}
@@ -193,8 +200,14 @@ jobs:
           VERSION: ${{ inputs.version }}
           DIST_TAG: ${{ needs.build.outputs.dist_tag }}
         run: npm publish "./ts-dedent-$VERSION.tgz" --provenance --access public --tag "$DIST_TAG"
-      - name: Push release commit and tag
-        run: git push origin master --follow-tags
+      # master is protected, so push the release commit to a dedicated branch and
+      # the tag (tags are not branch-protected). The branch feeds the PR below.
+      - name: Push release branch and tag
+        env:
+          VERSION: ${{ inputs.version }}
+        run: |
+          git push origin "HEAD:refs/heads/release/v$VERSION"
+          git push origin "refs/tags/v$VERSION"
       - name: Create GitHub release
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
@@ -211,3 +224,27 @@ jobs:
             gh release create "v$VERSION" "./ts-dedent-$VERSION.tgz" \
               --title "v$VERSION" --generate-notes $FLAG
           fi
+      # Open a PR so the version bump lands on master through review, not a direct
+      # push. Merge it manually (merge commit) to keep the v<version> tag in history.
+      - name: Open version-bump PR to master
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          VERSION: ${{ inputs.version }}
+          DIST_TAG: ${{ needs.build.outputs.dist_tag }}
+        run: |
+          {
+            echo "Automated release of \`v$VERSION\` (npm dist-tag: \`$DIST_TAG\`)."
+            echo
+            echo "\`v$VERSION\` is already published to npm with a GitHub release and git tag."
+            echo "This PR only brings the version bump (package.json, package-lock.json, HISTORY.md) into \`master\`."
+            echo
+            echo "Merge with a **merge commit** (not squash/rebase) so the \`v$VERSION\` tag stays in master history."
+            echo
+            echo "- npm: https://www.npmjs.com/package/ts-dedent/v/$VERSION"
+            echo "- Release: https://github.com/tamino-martinius/node-ts-dedent/releases/tag/v$VERSION"
+          } > "$RUNNER_TEMP/pr-body.md"
+          gh pr create \
+            --base master \
+            --head "release/v$VERSION" \
+            --title "chore(release): v$VERSION" \
+            --body-file "$RUNNER_TEMP/pr-body.md"

--- a/README.md
+++ b/README.md
@@ -85,25 +85,6 @@ console.log(dedent(`
 Wait! I lied. Dedent can also be used as a function.
 ```
 
-## Releasing
-
-Releases are automated by the [`Release` workflow](.github/workflows/release.yml): on GitHub go
-to **Actions → Release → Run workflow** on `master` and enter the version without a leading `v`
-(e.g. `2.3.0`, or `2.3.0-beta.1` for a prerelease). The workflow tests, verifies the packaged
-artifact on every maintained Node version across Linux/macOS/Windows, then publishes to npm with
-provenance, pushes the release commit + tag, and creates the GitHub release.
-
-Two one-time prerequisites must be configured before the first release:
-
-1. **npm trusted publisher** — on npmjs.com, add a GitHub Actions trusted publisher for the
-   `ts-dedent` package (repository `tamino-martinius/node-ts-dedent`, workflow `release.yml`).
-   Publishing is tokenless via OIDC `--provenance`; no `NPM_TOKEN` is stored.
-2. **Branch protection** — `master` must allow `github-actions[bot]` to push the release commit
-   and tag.
-
-Each release derives its notes from the `## vNext` section of [`HISTORY.md`](HISTORY.md), so put
-the changelog entries there (replacing `TBD`) before running the workflow.
-
 ## License
 
 MIT


### PR DESCRIPTION
## Why

Run [#26937910867](https://github.com/tamino-martinius/node-ts-dedent/actions/runs/26937910867) failed at the final step: the `publish` job pushed the version-bump commit straight to `master`, which branch protection rejects:

```
remote: error: GH006: Protected branch update failed for refs/heads/master.
remote: - Changes must be made through a pull request.
```

npm publish, the git tag, and the GitHub release all succeeded — only the direct push to `master` was blocked. This is a GitHub branch-protection issue, not an npm trusted-publishing one.

## What changed

**`.github/workflows/release.yml`**
- The `publish` job no longer pushes to `master`. It now pushes the release commit to a `release/v<version>` branch and **opens a PR to `master`** for the maintainer to merge manually.
- npm publish (OIDC `--provenance`), tagging, and GitHub release creation are unchanged.
- Added `pull-requests: write` permission.
- Updated header comment / prerequisites accordingly.

**`README.md`**
- Removed the `## Releasing` section (sole maintainer — it was just noise for readers). Prerequisites now live in the workflow header comment.

## Why this approach

Keeps `master` fully protected with **no bypass and no PAT** — pushing a new branch and opening a PR are both allowed for the default `GITHUB_TOKEN`. The "merge with a merge commit" convention is carried in the auto-generated PR body, where the releaser sees it at merge time.

## Notes

- A PR opened by `GITHUB_TOKEN` does **not** trigger `ci.yml` (GitHub blocks recursive workflow triggers). Fine here — the full `verify` matrix already runs inside the release workflow before publishing.
- One-time repo setting required (already enabled): *Settings → Actions → General → "Allow GitHub Actions to create and approve pull requests"*.
