### PR TITLE
fix(release): keep release notes in artifact by un-hiding the file

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -94,7 +94,7 @@ jobs:
         id: notes
         run: |
           set +e
-          node .github/scripts/release-compose-notes.mjs .release-notes.md
+          node .github/scripts/release-compose-notes.mjs release-notes.md
           code=$?
           set -e
           if [ "$code" = "0" ]; then
@@ -128,7 +128,7 @@ jobs:
             package.json
             package-lock.json
             HISTORY.md
-            .release-notes.md
+            release-notes.md
           if-no-files-found: ignore
 
   verify:
@@ -219,7 +219,7 @@ jobs:
           if [ "$IS_PRERELEASE" = "true" ]; then FLAG="--prerelease"; fi
           if [ "$HAVE_NOTES" = "true" ]; then
             gh release create "v$VERSION" "./ts-dedent-$VERSION.tgz" \
-              --title "v$VERSION" --notes-file .release-notes.md $FLAG
+              --title "v$VERSION" --notes-file release-notes.md $FLAG
           else
             gh release create "v$VERSION" "./ts-dedent-$VERSION.tgz" \
               --title "v$VERSION" --generate-notes $FLAG

--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@ coverage*
 node_modules
 npm-debug.log*
 .DS_Store
+release-notes.md


### PR DESCRIPTION
## Problem

The Release workflow failed on the publish step ([run 26940960580](https://github.com/tamino-martinius/node-ts-dedent/actions/runs/26940960580)) with:

```
open .release-notes.md: no such file or directory
```

This happened **after** the irreversible `npm publish` had already run, leaving a half-finished release (`2.3.0-beta.2` live on npm, tag + branch on origin, but no GitHub release and no version-bump PR).

## Root cause

`actions/upload-artifact@v4` **excludes hidden files by default** (since v4.4.0). The build job created `.release-notes.md` (a dotfile) and set `have_notes=true`, but the upload silently dropped it — the step's `path:` listed 4 files yet the log reads *"there will be 3 files uploaded"*, and `if-no-files-found: ignore` hid the gap. The publish job then ran `gh release create --notes-file .release-notes.md` against a file that never reached the artifact.

## Fix

- Rename the transient notes file `.release-notes.md` → `release-notes.md` (non-hidden) in all 3 spots in `release.yml`. It now rides the `release-files` artifact by default — no `include-hidden-files` workaround needed.
- Gitignore `release-notes.md`: it's a build artifact regenerated from `HISTORY.md` every run and is never committed (the workflow only `git add`s `package.json`, `package-lock.json`, `HISTORY.md`).

## Notes

The dangling `2.3.0-beta.2` is intentionally left as-is — it's a prerelease, `npm dist-tag latest` is still `2.2.0`.