### PR TITLE
docs: explain the dedent algorithm in the readme (#39)

### DIFF
--- a/HISTORY.md
+++ b/HISTORY.md
@@ -2,6 +2,7 @@
 
 ## vNext
 
+- Documented the dedent algorithm in the readme with a step-by-step "How it works" section (closes #39)
 - Added an automated release workflow: npm publish with provenance via OIDC trusted publishing, GitHub release creation, and automatic version/HISTORY maintenance
 - CI now verifies the packaged tarball (CommonJS `require`, ESM `import`, and TypeScript type resolution) on every maintained Node version (22/24/26) across Linux, macOS, and Windows
 - Fixed package `exports` to use per-condition `types` so TypeScript resolves the correct declarations for both ESM (`import`) and CommonJS (`require`) consumers

--- a/README.md
+++ b/README.md
@@ -85,6 +85,61 @@ console.log(dedent(`
 Wait! I lied. Dedent can also be used as a function.
 ```
 
+## How it works
+
+`dedent` runs the following steps on the string, in order:
+
+1. **Strip a single leading line break.** If the string starts with a newline
+   (the common case when you put your first line of text below the opening
+   backtick), that one newline is removed. A second blank line is kept, so you
+   can intentionally start the output with an empty line.
+2. **Strip a single trailing line break and its indentation.** A trailing
+   newline followed only by spaces/tabs is removed. This is what lets you put
+   the closing backtick on its own indented line without adding a blank line to
+   the result.
+3. **Find the common indentation.** For every line that contains actual
+   content, `dedent` counts its leading spaces and tabs. The "common
+   indentation" is the **smallest** of those counts — i.e. the line with the
+   _fewest_ leading whitespace characters. Blank lines are ignored, and a line
+   that starts with a non-whitespace character counts as `0` (so if any content
+   line has no indentation, nothing is stripped).
+4. **Remove the common indentation from every line.** Exactly that many leading
+   whitespace characters are removed from the start of each line. Lines that
+   were indented further keep the difference, so relative indentation (nested
+   lists, code blocks, etc.) is preserved.
+5. **Interpolate the placeholders.** `${...}` values are inserted. If a value is
+   itself a multi-line string, every line after its first is re-indented to
+   match the placeholder's position, so nested/multi-line values stay aligned.
+
+So to answer the common question directly: it removes the indentation of the
+line with the **fewest** leading whitespace characters — not the first indented
+line — and applies that same removal to every line.
+
+A few details worth knowing:
+
+- Indentation is counted in **characters**, where each tab and each space
+  counts as one. Removal also works on raw characters, so mixing tabs and
+  spaces in your leading whitespace can give surprising results — pick one and
+  be consistent.
+- Only **one** leading and **one** trailing line break are trimmed. Additional
+  blank lines at the very start or end are preserved.
+
+```js
+// Lines indented by 4, 2, and 6 spaces. The minimum is 2, so 2 spaces are
+// removed from every line:
+console.log(dedent`
+    four
+  two
+      six
+`);
+```
+
+```txt
+  four
+two
+    six
+```
+
 ## License
 
 MIT


### PR DESCRIPTION
## Summary

Adds a **"How it works"** section to `README.md` that documents exactly what `dedent` does, addressing issue #39.

The section walks through the algorithm in order:

1. Strip a single leading line break.
2. Strip a single trailing line break and its indentation.
3. Find the common indentation = the **smallest** leading-whitespace count across content lines (blank lines ignored; a non-indented content line forces it to `0`).
4. Remove that common indentation from every line, preserving relative indentation.
5. Interpolate placeholders, re-indenting multiline values to the placeholder's position.

It explicitly answers the reporter's question — the removed indentation is determined by the line with the **fewest** leading whitespace characters, not the first indented line — and calls out two gotchas (indentation is counted in raw characters, so don't mix tabs and spaces; only one leading and one trailing break are trimmed). A small 4/2/6-space example shows the minimum (2) being stripped from all lines.

Verified the documented behavior against `src/index.ts` (`Math.min(...indentLengths)`) and empirically against the built ESM module.

## Changes

- `README.md` — new "How it works" section.
- `HISTORY.md` — `vNext` entry noting the docs change.

Docs-only; no source or tests changed.

Closes #39